### PR TITLE
Remove token from Codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
         if: ${{ matrix.run-coverage && github.repository == 'Ajimaru/OctoPrint-Uptime' }}
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: unittests
           fail_ci_if_error: false


### PR DESCRIPTION
This pull request makes a minor change to the CI workflow configuration by removing the `CODECOV_TOKEN` secret from the Codecov upload step. This simplifies the process of uploading coverage reports, likely relying on repository-level authentication instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed CODECOV_TOKEN from the Codecov upload step to rely on repository-level authentication and reduce secret management. Coverage uploads still use coverage.xml with flags, and the step remains non-blocking (fail_ci_if_error: false).

<sup>Written for commit b4c2387033c3d7e8f7e1e4177ea24d3ffa292591. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration for coverage reporting workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->