### PR TITLE
Update test coverage command in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run tests (with coverage)
         if: ${{ matrix.run-coverage }}
         run: |
-          pytest -q --cov=modul --cov-branch --cov-report=xml:coverage.xml
+          pytest -q --cov=octoprint_uptime --cov-branch --cov-report=xml:coverage.xml
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.run-coverage && github.repository == 'Ajimaru/OctoPrint-Uptime' }}


### PR DESCRIPTION
# Pull Request

<!-- English only: please write PR descriptions and discussions in English. -->

- What does this change do?

This pull request updates the test coverage configuration in the CI workflow to target the correct module for coverage reporting.

Testing configuration:

* Changed the coverage target in `.github/workflows/ci.yml` from `modul` to `octoprint_uptime` to ensure coverage reports are generated for the intended module.

## Checklist

- [ ] Public-facing text is in English
- [ ] Tests pass (`pytest`)
- [ ] Lint/formatting passes (`pre-commit run --all-files`)
- [ ] Docs updated (if needed)
- [x] Workflow changes (if any) keep least-privilege `permissions:` and avoid `pull_request_target` unless strictly necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated CI test coverage to target the octoprint_uptime module instead of modul. This ensures accurate coverage reports and correct uploads to Codecov.

<sup>Written for commit adedfbba7d29a0cb325ce19feb5da0a70e964b89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow test coverage configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->