### PR TITLE
improve the GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,12 @@ jobs:
 
       - name: Read release title
         id: release_title
-        run: echo "title=$(cat release_title.txt)" >> $GITHUB_OUTPUT
+        run: |
+          {
+            echo 'title<<EOF'
+            cat release_title.txt
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
# Pull Request

This pull request updates the project version to 0.2.1 and improves the GitHub release workflow by ensuring the release title is more descriptive and properly set during automated releases.

Version bump:

* Updated the version number from 0.2.0 to 0.2.1 in both `pyproject.toml` and `octoprint_uptime/_version.py` to reflect the new release. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L11-R11) [[2]](diffhunk://#diff-49902aaa8b5493928a4e6a173ec6de361f4b4e8fe7ba9835e8bd3d561f668e81L8-R8)

GitHub Actions workflow improvements:

* Changed the release title format in `.github/workflows/release.yml` to include the project name, resulting in titles like "OctoPrint-Uptime 0.2.1" or "OctoPrint-Uptime Prerelease 0.2.1".
* Added steps to write the release title to a file and read it back into the workflow, ensuring the correct title is used when creating the GitHub Release.

## Checklist

- [ ] Public-facing text is in English
- [ ] Tests pass (`pytest`)
- [ ] Lint/formatting passes (`pre-commit run --all-files`)
- [ ] Docs updated (if needed)
- [x] Workflow changes (if any) keep least-privilege `permissions:` and avoid `pull_request_target` unless strictly necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release titles now consistently include the "OctoPrint-Uptime" prefix for both prerelease and release builds.
  * Workflow stores the generated release title and exposes it as the workflow output for use by the release step.
  * Release publishing step now consumes the exported title to ensure consistent release naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->