### PR TITLE
chore: sync pre-commit eslint hook and declare node engines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,12 +39,12 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.0.0
+    rev: v10.2.0
     hooks:
       - id: eslint # JavaScript/TypeScript linter (ESLint)
         files: "(\\.js)$"
         exclude: ^(src/octoprint/vendor/|tests/static/js/lib|tests/util/_files|docs/|scripts/|translations/)
-        additional_dependencies: ["eslint@10.0.0", "globals@17.3.0"]
+        additional_dependencies: ["eslint@10.2.0", "globals@17.5.0"]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "devDependencies": {
     "eslint": "10.0.0",
     "globals": "17.3.0",


### PR DESCRIPTION
Addresses the two Copilot review comments raised on PR #64.

## Changes
- **`.pre-commit-config.yaml`**: bump `mirrors-eslint` `rev` to `v10.2.0` and update `additional_dependencies` to `eslint@10.2.0` / `globals@17.5.0` so the pre-commit ESLint hook matches the devDependency versions arriving in PR #64. Prevents drift between local pre-commit linting and `npm`-driven linting.
- **`package.json`**: declare `"engines": { "node": ">=20.19.0" }` to match the Node version floor required by ESLint 10.2.0's transitive dependencies (`^20.19.0 || ^22.13.0 || >=24`). Avoids `EBADENGINE` warnings on older Node versions.

Refs #64.