### PR TITLE
chore: drop Python 3.8 support, raise minimum to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.8"
-            os: ubuntu-latest
-            run-precommit: false # Modern pre-commit hooks require Python >= 3.10
-            run-coverage: false
-            run-build: false
           - python-version: "3.9"
             os: ubuntu-latest
             run-precommit: false # Modern pre-commit hooks require Python >= 3.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade # Modernize Python syntax to newer constructs (pyupgrade)
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
         exclude: "setup.py"
 
   # Linters and security

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- markdownlint-enable MD041 MD033 -->
 
 [![License](https://img.shields.io/github/license/Ajimaru/OctoPrint-Uptime)](https://github.com/Ajimaru/OctoPrint-Uptime/blob/main/LICENSE)
-[![Python](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://python.org)
+[![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://python.org)
 [![OctoPrint](https://img.shields.io/badge/OctoPrint-1.10.0%2B-blue.svg)](https://octoprint.org)
 [![Latest Release](https://img.shields.io/github/v/release/Ajimaru/OctoPrint-Uptime?sort=semver)](https://github.com/Ajimaru/OctoPrint-Uptime/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/Ajimaru/OctoPrint-Uptime/total.svg)](https://github.com/Ajimaru/OctoPrint-Uptime/releases)
@@ -164,7 +164,7 @@ Summary: this project exposes many status and quality badges (CI, linting, cover
 [![Latest Release](https://img.shields.io/github/v/release/Ajimaru/OctoPrint-Uptime?sort=semver)](https://github.com/Ajimaru/OctoPrint-Uptime/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/Ajimaru/OctoPrint-Uptime/total.svg)](https://github.com/Ajimaru/OctoPrint-Uptime/releases)
 [![Pre‑Release](https://img.shields.io/github/v/release/Ajimaru/OctoPrint-Uptime?include_prereleases&label=pre-release)](https://github.com/Ajimaru/OctoPrint-Uptime/releases)
-[![Python](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://python.org)
+[![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://python.org)
 [![OctoPrint](https://img.shields.io/badge/OctoPrint-1.10.0%2B-blue.svg)](https://octoprint.org)
 [![Maintenance](https://img.shields.io/maintenance/yes/2026)](https://github.com/Ajimaru/OctoPrint-Uptime/graphs/commit-activity)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ OctoPrint-Uptime is a plugin for OctoPrint that displays both system and OctoPri
 
 ### Prerequisites
 
-- OctoPrint 1.10.0+ (Python 3.8+)
+- OctoPrint 1.10.0+ (Python 3.9+)
 - Node.js 20+ (for frontend development)
 - mkdocs (for documentation)
 

--- a/extras/octoprint_uptime.md
+++ b/extras/octoprint_uptime.md
@@ -35,7 +35,7 @@ compatibility:
     - 1.10.0
   os:
     - linux
-  python: ">=3.8,<4"
+  python: ">=3.9,<4"
 ---
 
 OctoPrint-Uptime is a lightweight plugin that displays both the host system uptime and OctoPrint process uptime in the navbar. Additionally, it provides a small, authenticated JSON API that can be queried by external tools or scripts.

--- a/octoprint_uptime/__init__.py
+++ b/octoprint_uptime/__init__.py
@@ -35,5 +35,5 @@ __plugin_description__ = "Adds system uptime to the navbar and exposes a small u
 __plugin_author__ = "Ajimaru"
 __plugin_url__ = "https://github.com/Ajimaru/OctoPrint-Uptime"
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.8,<4"
+__plugin_pythoncompat__ = ">=3.9,<4"
 __plugin_implementation__ = OctoprintUptimePlugin()

--- a/octoprint_uptime/plugin.py
+++ b/octoprint_uptime/plugin.py
@@ -10,7 +10,7 @@ import importlib
 import inspect
 import os
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 try:
     from ._version import VERSION
@@ -186,7 +186,7 @@ class OctoprintUptimePlugin(
         self._debug_throttle_seconds: int = 60
         self._last_uptime_source: Optional[str] = None
 
-    def get_update_information(self) -> Dict[str, Any]:
+    def get_update_information(self) -> dict[str, Any]:
         """Return update information for the OctoPrint-Uptime plugin.
 
         This method provides metadata required for OctoPrint's update mechanism.
@@ -195,7 +195,7 @@ class OctoprintUptimePlugin(
             dict: Update information dictionary.
         """
 
-        info: Dict[str, Any] = {
+        info: dict[str, Any] = {
             "octoprint_uptime": {
                 "displayName": "OctoPrint-Uptime",
                 "displayVersion": VERSION,
@@ -217,7 +217,7 @@ class OctoprintUptimePlugin(
         result: bool = True
         return result
 
-    def get_assets(self) -> Dict[str, List[str]]:
+    def get_assets(self) -> dict[str, list[str]]:
         """Return plugin asset files for OctoPrint-Uptime.
 
         Returns:
@@ -225,7 +225,7 @@ class OctoprintUptimePlugin(
         """
         return {"js": ["js/uptime.js"]}
 
-    def get_template_configs(self) -> List[Dict[str, Any]]:
+    def get_template_configs(self) -> list[dict[str, Any]]:
         """
         Returns a list of template configuration dictionaries for the OctoPrint plugin.
 
@@ -260,7 +260,7 @@ class OctoprintUptimePlugin(
         """
         return True
 
-    def _get_uptime_seconds(self) -> Tuple[Optional[float], str]:
+    def _get_uptime_seconds(self) -> tuple[Optional[float], str]:
         """Attempts to retrieve system uptime using several strategies.
 
         Returns a tuple of (seconds|None, source) where source is one of
@@ -389,7 +389,7 @@ class OctoprintUptimePlugin(
         if callable(hook):
             self._invoke_settings_hook(hook)
 
-    def on_settings_save(self, data: Dict[str, Any]) -> None:
+    def on_settings_save(self, data: dict[str, Any]) -> None:
         """
         Save plugin settings, validate config values, and update internal state.
 
@@ -479,7 +479,7 @@ class OctoprintUptimePlugin(
 
         self._safe_invoke_hook(hook, param_count)
 
-    def _validate_and_sanitize_settings(self, data: Dict[str, Any]) -> None:
+    def _validate_and_sanitize_settings(self, data: dict[str, Any]) -> None:
         """Validate and sanitize plugin settings in the provided data dict."""
         plugins = data.get("plugins") if isinstance(data, dict) else None
         if not isinstance(plugins, dict):
@@ -503,7 +503,7 @@ class OctoprintUptimePlugin(
                 val = max(lo, min(val, hi))
                 uptime_cfg[key] = val
 
-    def _log_settings_save_data(self, data: Dict[str, Any]) -> None:
+    def _log_settings_save_data(self, data: dict[str, Any]) -> None:
         """
         Logs the data passed to the settings save event for debugging purposes.
 
@@ -521,7 +521,7 @@ class OctoprintUptimePlugin(
             except (AttributeError, TypeError, ValueError):
                 pass
 
-    def _call_base_on_settings_save(self, data: Dict[str, Any]) -> None:
+    def _call_base_on_settings_save(self, data: dict[str, Any]) -> None:
         """
         Calls the base class's `on_settings_save` method with the provided data if it exists
         and is callable.
@@ -542,7 +542,7 @@ class OctoprintUptimePlugin(
             except (AttributeError, TypeError, ValueError):
                 pass
 
-    def get_settings_defaults(self) -> Dict[str, Any]:
+    def get_settings_defaults(self) -> dict[str, Any]:
         """Return default settings for the plugin.
 
         OctoPrint populates `settings.plugins.<identifier>` from this mapping so the
@@ -763,7 +763,7 @@ class OctoprintUptimePlugin(
         # permission enforcement is required.
         return True
 
-    def _abort_forbidden(self) -> Dict[str, str]:
+    def _abort_forbidden(self) -> dict[str, str]:
         """
         Handles forbidden access attempts by aborting the request with a 403 status code if
         Flask is available, and returns a JSON error message indicating the action is
@@ -777,7 +777,7 @@ class OctoprintUptimePlugin(
             _flask.abort(403)
         return {"error": _("Forbidden")}
 
-    def _get_uptime_info(self) -> Tuple[Optional[float], str, str, str, str]:
+    def _get_uptime_info(self) -> tuple[Optional[float], str, str, str, str]:
         """
         Retrieve uptime information and formatted strings.
 
@@ -808,7 +808,7 @@ class OctoprintUptimePlugin(
 
     def _format_uptime_tuple(
         self, seconds: Optional[float]
-    ) -> Tuple[Optional[float], str, str, str, str]:
+    ) -> tuple[Optional[float], str, str, str, str]:
         """
         Normalize and format an uptime value into display strings.
         """
@@ -826,7 +826,7 @@ class OctoprintUptimePlugin(
             uptime_full = uptime_dhm = uptime_dh = uptime_d = _("unknown")
         return seconds, uptime_full, uptime_dhm, uptime_dh, uptime_d
 
-    def _get_octoprint_uptime_info(self) -> Tuple[Optional[float], str, str, str, str]:
+    def _get_octoprint_uptime_info(self) -> tuple[Optional[float], str, str, str, str]:
         """
         Retrieve OctoPrint process uptime information and formatted strings.
 
@@ -843,7 +843,7 @@ class OctoprintUptimePlugin(
                 pass
             return self._format_uptime_tuple(None)
 
-    def _get_api_settings(self) -> Tuple[str, int]:
+    def _get_api_settings(self) -> tuple[str, int]:
         """
         Retrieves and returns the plugin's API settings with appropriate fallbacks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,4 +64,4 @@ develop = [
 
 [tool.black]
 line-length = 100
-target-version = ["py39", "py310", "py311", "py312", "py313"]
+target-version = ["py39", "py310", "py311", "py312"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
 
-requires-python = ">=3.8, <4"
+requires-python = ">=3.9, <4"
 license = {text = "AGPL-3.0-or-later"}
 
 dynamic = [
@@ -64,4 +64,4 @@ develop = [
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]

--- a/scripts/translation_utils.py
+++ b/scripts/translation_utils.py
@@ -5,8 +5,8 @@ Shared utilities for translation file management.
 This module provides common functions used by translation management scripts.
 """
 
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator
 
 
 def iter_po_files(root: Path) -> Iterator[Path]:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """OctoPrint Uptime plugin setup module.
 
 Provides packaging metadata for the OctoPrint-Uptime plugin.
@@ -7,7 +6,7 @@ Provides packaging metadata for the OctoPrint-Uptime plugin.
 import copy
 import os
 import re
-from typing import List, Optional
+from typing import Optional
 
 from setuptools import setup
 
@@ -41,7 +40,7 @@ def _read_version():
     version = "0.0.0"
     version_pattern = re.compile(r'^VERSION\s*=\s*[\'"]([^\'"]+)[\'"]')
     try:
-        with open(ver_path, "r", encoding="utf-8") as f:
+        with open(ver_path, encoding="utf-8") as f:
             for line in f:
                 match = version_pattern.match(line)
                 if match:
@@ -83,15 +82,15 @@ PLUGIN_URL = "https://github.com/Ajimaru/OctoPrint-Uptime"
 # so python setup.py sdist produces a source distribution that contains
 # all your files (see http://stackoverflow.com/a/14159430/2028598).
 
-PLUGIN_ADDITIONAL_DATA: List[str] = []
+PLUGIN_ADDITIONAL_DATA: list[str] = []
 
 # Any additional python packages you need to install with your plugin that
 # are not contained in <plugin_package>.*.
-PLUGIN_ADDITIONAL_PACKAGES: List[str] = []
+PLUGIN_ADDITIONAL_PACKAGES: list[str] = []
 
 # Any python packages within <plugin_package>.* you do NOT want to install
 # with your plugin.
-PLUGIN_IGNORED_PACKAGES: List[str] = []
+PLUGIN_IGNORED_PACKAGES: list[str] = []
 
 # Additional parameters for the call to setuptools.setup.
 # If your plugin wants to register additional entry points,

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ PLUGIN_IGNORED_PACKAGES: List[str] = []
 # to prevent confused users and provide a helpful error.
 # Remove it if you would like to support Python 2 as well as 3
 # (not recommended).
-additional_setup_parameters = {"python_requires": ">=3.8,<4"}
+additional_setup_parameters = {"python_requires": ">=3.9,<4"}
 
 ####################################################################
 


### PR DESCRIPTION
## Why

Python 3.8 reached end-of-life in October 2024. Several dev tools declared in the `[develop]` extra (`pylint>=3.3.9`, `flake8>=7.0.0`, modern `pre-commit`) have already dropped Python 3.8 support, which is why the `Test (Python 3.8)` CI job currently fails at dependency installation on `dev`.

Raising the minimum to **Python 3.9** is the safe near-term cleanup:
- 3.9 is still available on Raspberry Pi OS Bullseye (oldstable, EOL Aug 2026), so no current user is excluded.
- Aligns the plugin with where the dev-tool ecosystem already is.
- Unblocks CI on `dev`, PR #65 and PR #64.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | `requires-python = ">=3.9, <4"` |
| `pyproject.toml` `[tool.black]` | `target-version = ["py39", "py310", "py311", "py312", "py313"]` |
| `setup.py` | `python_requires = ">=3.9,<4"` |
| `octoprint_uptime/__init__.py` | `__plugin_pythoncompat__ = ">=3.9,<4"` |
| `.pre-commit-config.yaml` | `pyupgrade --py39-plus` |
| `.github/workflows/ci.yml` | remove Python 3.8 matrix entry |
| `README.md`, `docs/index.md`, `extras/octoprint_uptime.md` | bump documented minimum to 3.9 |

No source code changes — `octoprint_uptime/plugin.py` already runs cleanly on 3.9+.

## Compatibility note

OctoPrint Core itself still officially supports Python 3.7 → 3.13. Plugins are allowed to require higher minimums; OctoPrint will surface a clear compatibility warning to users on Python <3.9 at install time.
