### PR TITLE
fix(ci): unblock PR #77 checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,6 @@ gh_logs/
 
 # === Local Configuration ===
 .python-version
-.pre-commit-config.yaml
 .githooks/
 
 # === Generated API Docs ===

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,98 @@
+default_language_version:
+  python: python3
+
+exclude: '^docs/api/python\.md$'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: check-added-large-files
+      - id: check-symlinks
+      - id: check-case-conflict
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+        exclude: '^translations/.*\.(po|pot)$'
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-ast
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-xml
+      - id: debug-statements
+
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        language_version: python3
+
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v10.2.0
+    hooks:
+      - id: eslint
+        files: "(\\.js)$"
+        exclude: ^(src/octoprint/vendor/|tests/static/js/lib|tests/util/_files|docs/|scripts/|translations/)
+        additional_dependencies: ["eslint@10.2.0", "globals@17.5.0"]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.14
+    hooks:
+      - id: ruff-check
+        args: ["--fix"]
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
+    hooks:
+      - id: pyupgrade
+        args: ["--py39-plus"]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        exclude: '\\.md$|\\.yaml$|\\.yml$|\\.json$|\\.txt$|\\.po$|\\.pot$|\\.mo$'
+        args: ["--max-line-length=100", "--extend-ignore=E203,W503"]
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.3
+    hooks:
+      - id: bandit
+        args: ["-x", "tests,.venv,venv,.git", "-ll"]
+
+  - repo: https://github.com/djlint/djlint
+    rev: v1.36.4
+    hooks:
+      - id: djlint-reformat
+        files: "\\.(html|jinja2|j2)$"
+        exclude: "^docs/(development/testing-diagrams|reference/diagrams)/"
+        types: [html]
+      - id: djlint-reformat-jinja
+        files: "\\.(html|jinja2|j2)$"
+        exclude: "^docs/(development/testing-diagrams|reference/diagrams)/"
+
+  - repo: https://github.com/OctoPrint/pre-commit-lessc
+    rev: 4.4.0
+    hooks:
+      - id: lessc
+        args: ["--wrapper-quiet", "--clean-css=--s1 --advanced --compatibility=ie8"]
+        additional_dependencies: ["less-plugin-clean-css"]
+        files: ^octoprint_uptime/static/less/.*\\.less$
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args: ["-L", "te,nd,inh"]
+        exclude: "(^site/|^node_modules/|^translations/.*\\.(po|pot)$)"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-04-27 12:31+0200\n"
+"POT-Creation-Date: 2026-05-02 17:18+0200\n"
 "PO-Revision-Date: 2026-02-18 21:35+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -78,16 +78,16 @@ msgstr "Anzeigeformat"
 msgid "Enable debug logging (throttled)"
 msgstr "Debug-Protokollierung aktivieren (gedrosselt)"
 
-#: octoprint_uptime/plugin.py:841
+#: octoprint_uptime/plugin.py:829
 msgid "Error computing OctoPrint uptime"
 msgstr "Fehler bei der Ermittlung der OctoPrint-Uptime"
 
-#: octoprint_uptime/plugin.py:804
+#: octoprint_uptime/plugin.py:795
 msgid "Error computing uptime"
 msgstr "Fehler bei der Ermittlung der Uptime"
 
-#: octoprint_uptime/plugin.py:742 octoprint_uptime/plugin.py:749
-#: octoprint_uptime/plugin.py:778
+#: octoprint_uptime/plugin.py:736 octoprint_uptime/plugin.py:743
+#: octoprint_uptime/plugin.py:770
 msgid "Forbidden"
 msgstr "Zugriff verweigert"
 
@@ -103,17 +103,9 @@ msgstr "OctoPrint"
 msgid "OctoPrint Started:"
 msgstr "OctoPrint gestartet:"
 
-#: octoprint_uptime/plugin.py:248
-msgid "OctoPrint Uptime"
-msgstr "OctoPrint-Uptime"
-
 #: octoprint_uptime/templates/settings.jinja2:92
 msgid "OctoPrint Uptime:"
 msgstr "OctoPrint-Uptime:"
-
-#: octoprint_uptime/templates/settings.jinja2:3
-msgid "OctoPrint-Uptime"
-msgstr "OctoPrint-Uptime"
 
 #: octoprint_uptime/templates/settings.jinja2:143
 msgid "Polling interval (s)"
@@ -147,12 +139,17 @@ msgstr "System-Uptime:"
 msgid "Toggle between system and OctoPrint uptime in the navbar"
 msgstr "Zwischen System- und OctoPrint-Uptime wechseln"
 
-#: octoprint_uptime/plugin.py:708
+#: octoprint_uptime/plugin.py:249 octoprint_uptime/templates/settings.jinja2:3
+#, fuzzy
+msgid "Uptime"
+msgstr "Uptime:"
+
+#: octoprint_uptime/plugin.py:703
 #, python-format
 msgid "Uptime API requested, result=%s"
 msgstr "Uptime-API angefragt, Ergebnis=%s"
 
-#: octoprint_uptime/plugin.py:664 octoprint_uptime/plugin.py:680
+#: octoprint_uptime/plugin.py:661 octoprint_uptime/plugin.py:677
 #: octoprint_uptime/templates/settings.jinja2:6
 msgid "Uptime could not be determined on this system."
 msgstr "Die Uptime konnte auf diesem System nicht ermittelt werden."
@@ -179,16 +176,22 @@ msgstr "Wenn aktiviert, wird die System-Uptime in der Navbar angezeigt."
 msgid "When enabled, writes throttled debug logs."
 msgstr "Wenn aktiviert, schreibt das Plugin gedrosselte Debug-Logs."
 
-#: octoprint_uptime/plugin.py:864 octoprint_uptime/plugin.py:870
+#: octoprint_uptime/plugin.py:851 octoprint_uptime/plugin.py:857
 msgid "full"
 msgstr "voll"
 
-#: octoprint_uptime/plugin.py:242
+#: octoprint_uptime/plugin.py:243
 msgid "navbar_uptime"
 msgstr "Navbar-Uptime"
 
-#: octoprint_uptime/plugin.py:649 octoprint_uptime/plugin.py:690
-#: octoprint_uptime/plugin.py:826
+#: octoprint_uptime/plugin.py:646 octoprint_uptime/plugin.py:687
+#: octoprint_uptime/plugin.py:815
 msgid "unknown"
 msgstr "unbekannt"
+
+#~ msgid "OctoPrint Uptime"
+#~ msgstr "OctoPrint-Uptime"
+
+#~ msgid "OctoPrint-Uptime"
+#~ msgstr "OctoPrint-Uptime"
 

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-04-27 12:31+0200\n"
+"POT-Creation-Date: 2026-05-02 17:18+0200\n"
 "PO-Revision-Date: 2026-01-19 21:32+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -76,16 +76,16 @@ msgstr ""
 msgid "Enable debug logging (throttled)"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:841
+#: octoprint_uptime/plugin.py:829
 msgid "Error computing OctoPrint uptime"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:804
+#: octoprint_uptime/plugin.py:795
 msgid "Error computing uptime"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:742 octoprint_uptime/plugin.py:749
-#: octoprint_uptime/plugin.py:778
+#: octoprint_uptime/plugin.py:736 octoprint_uptime/plugin.py:743
+#: octoprint_uptime/plugin.py:770
 msgid "Forbidden"
 msgstr ""
 
@@ -101,16 +101,8 @@ msgstr ""
 msgid "OctoPrint Started:"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:248
-msgid "OctoPrint Uptime"
-msgstr ""
-
 #: octoprint_uptime/templates/settings.jinja2:92
 msgid "OctoPrint Uptime:"
-msgstr ""
-
-#: octoprint_uptime/templates/settings.jinja2:3
-msgid "OctoPrint-Uptime"
 msgstr ""
 
 #: octoprint_uptime/templates/settings.jinja2:143
@@ -145,12 +137,17 @@ msgstr ""
 msgid "Toggle between system and OctoPrint uptime in the navbar"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:708
+#: octoprint_uptime/plugin.py:249 octoprint_uptime/templates/settings.jinja2:3
+#, fuzzy
+msgid "Uptime"
+msgstr "Uptime:"
+
+#: octoprint_uptime/plugin.py:703
 #, python-format
 msgid "Uptime API requested, result=%s"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:664 octoprint_uptime/plugin.py:680
+#: octoprint_uptime/plugin.py:661 octoprint_uptime/plugin.py:677
 #: octoprint_uptime/templates/settings.jinja2:6
 msgid "Uptime could not be determined on this system."
 msgstr ""
@@ -175,16 +172,22 @@ msgstr ""
 msgid "When enabled, writes throttled debug logs."
 msgstr ""
 
-#: octoprint_uptime/plugin.py:864 octoprint_uptime/plugin.py:870
+#: octoprint_uptime/plugin.py:851 octoprint_uptime/plugin.py:857
 msgid "full"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:242
+#: octoprint_uptime/plugin.py:243
 msgid "navbar_uptime"
 msgstr "Uptime"
 
-#: octoprint_uptime/plugin.py:649 octoprint_uptime/plugin.py:690
-#: octoprint_uptime/plugin.py:826
+#: octoprint_uptime/plugin.py:646 octoprint_uptime/plugin.py:687
+#: octoprint_uptime/plugin.py:815
 msgid "unknown"
 msgstr ""
+
+#~ msgid "OctoPrint Uptime"
+#~ msgstr ""
+
+#~ msgid "OctoPrint-Uptime"
+#~ msgstr ""
 

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-04-27 12:31+0200\n"
+"POT-Creation-Date: 2026-05-02 17:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -75,16 +75,16 @@ msgstr ""
 msgid "Enable debug logging (throttled)"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:841
+#: octoprint_uptime/plugin.py:829
 msgid "Error computing OctoPrint uptime"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:804
+#: octoprint_uptime/plugin.py:795
 msgid "Error computing uptime"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:742 octoprint_uptime/plugin.py:749
-#: octoprint_uptime/plugin.py:778
+#: octoprint_uptime/plugin.py:736 octoprint_uptime/plugin.py:743
+#: octoprint_uptime/plugin.py:770
 msgid "Forbidden"
 msgstr ""
 
@@ -100,16 +100,8 @@ msgstr ""
 msgid "OctoPrint Started:"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:248
-msgid "OctoPrint Uptime"
-msgstr ""
-
 #: octoprint_uptime/templates/settings.jinja2:92
 msgid "OctoPrint Uptime:"
-msgstr ""
-
-#: octoprint_uptime/templates/settings.jinja2:3
-msgid "OctoPrint-Uptime"
 msgstr ""
 
 #: octoprint_uptime/templates/settings.jinja2:143
@@ -144,12 +136,16 @@ msgstr ""
 msgid "Toggle between system and OctoPrint uptime in the navbar"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:708
+#: octoprint_uptime/plugin.py:249 octoprint_uptime/templates/settings.jinja2:3
+msgid "Uptime"
+msgstr ""
+
+#: octoprint_uptime/plugin.py:703
 #, python-format
 msgid "Uptime API requested, result=%s"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:664 octoprint_uptime/plugin.py:680
+#: octoprint_uptime/plugin.py:661 octoprint_uptime/plugin.py:677
 #: octoprint_uptime/templates/settings.jinja2:6
 msgid "Uptime could not be determined on this system."
 msgstr ""
@@ -174,16 +170,16 @@ msgstr ""
 msgid "When enabled, writes throttled debug logs."
 msgstr ""
 
-#: octoprint_uptime/plugin.py:864 octoprint_uptime/plugin.py:870
+#: octoprint_uptime/plugin.py:851 octoprint_uptime/plugin.py:857
 msgid "full"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:242
+#: octoprint_uptime/plugin.py:243
 msgid "navbar_uptime"
 msgstr ""
 
-#: octoprint_uptime/plugin.py:649 octoprint_uptime/plugin.py:690
-#: octoprint_uptime/plugin.py:826
+#: octoprint_uptime/plugin.py:646 octoprint_uptime/plugin.py:687
+#: octoprint_uptime/plugin.py:815
 msgid "unknown"
 msgstr ""
 


### PR DESCRIPTION
Fixes failing checks seen on PR #77:\n\n- restore tracked  required by Lint/CI pre-commit steps\n- remove accidental ignore of  from \n- regenerate i18n catalogs (, , ) so i18n check matches extraction output\n\nAfter this PR is merged into , PR #77 should rerun with Lint/CI/i18n checks unblocked.