### PR TITLE
fix(ci): switch Codacy coverage upload to repository token auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,7 @@ jobs:
         name: Upload coverage to Codacy
         if: ${{ matrix.run-coverage && github.repository == 'Ajimaru/OctoPrint-Uptime' }}
         env:
-          CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
-          CODACY_ORGANIZATION_PROVIDER: ${{ vars.CODACY_ORGANIZATION_PROVIDER }}
-          CODACY_USERNAME: ${{ vars.CODACY_USERNAME }}
-          CODACY_PROJECT_NAME: ${{ vars.CODACY_PROJECT_NAME }}
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
         continue-on-error: true
         run: |
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml


### PR DESCRIPTION
## Summary

- Switch Codacy coverage upload from multi-repo account token auth to repository token auth (`CODACY_PROJECT_TOKEN`)
- Regenerate i18n catalogs after docstring line number shifts
- Fix pre-commit version pins (ESLint `v10.4.0`, ruff `v0.15.15`) to match `package.json` / `requirements-dev.txt`

## Root cause

The `CODACY_API_TOKEN` secret holds a **repository API token**, not an account-level token. The multi-repo auth flow (`CODACY_ORGANIZATION_PROVIDER` + `CODACY_USERNAME` + `CODACY_PROJECT_NAME`) requires an account token — using a repo token with those vars caused "Request URL not found" on every upload attempt.

Fix: expose the token as `CODACY_PROJECT_TOKEN` (the env var the reporter expects for single-repo auth) and remove the unused org vars.

## Test plan

- [ ] CI passes on this PR
- [ ] "Upload coverage to Codacy" step succeeds (no "Failed to upload" in logs)
- [ ] Codacy dashboard shows updated coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)